### PR TITLE
fix: pomsky-wasm as a plugin dep for Vite

### DIFF
--- a/pomsky-wasm/pkg/package.json
+++ b/pomsky-wasm/pkg/package.json
@@ -18,6 +18,8 @@
     "LICENSE_MIT",
     "LICENSE_APACHE"
   ],
+  "main": "pomsky_wasm.js",
+  "type": "module",
   "module": "pomsky_wasm.js",
   "homepage": "https://pomsky-lang.org",
   "types": "pomsky_wasm.d.ts",


### PR DESCRIPTION
<!--
    The title should start with one of the following:
        feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
    For example: "feat: frobnicate syntax"
-->

# Description

It turns out Vite, and probably some other bundlers, don't recognize the `module` property in `pomsky-wasm`'s `package.json`. Adding the `main` and `type` properties on top of that make it work properly in `unplugin-pomsky`.

To fully fix this, `pomsky-wasm` will need to be updated with that change, and `unplugin-pomsky` will have to upgrade the `pomsky-wasm` version.

<!-- Checklist:
   - My code is formatted with `cargo fmt`
   - My code compiles with the latest stable Rust toolchain
   - All tests pass with `cargo test`
   - My changes generate no new warnings with `cargo clippy`
   - I have commented my code, particularly in hard to understand areas
   - My changes are covered by tests, if needed
-->
