### PR TITLE
refactor: Use runtime arguments in Divan benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,22 +241,23 @@ dependencies = [
 
 [[package]]
 name = "divan"
-version = "0.1.2"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fab20f5802e0b897093184f5dc5d23447fa715604f238dc798f6da188b230019"
+checksum = "5398159ee27f2b123d89b856bad61725442f37df5fb98c30cd570c318d594aee"
 dependencies = [
+ "cfg-if",
  "clap",
  "condtype",
  "divan-macros",
- "linkme",
+ "libc",
  "regex-lite",
 ]
 
 [[package]]
 name = "divan-macros"
-version = "0.1.2"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c5d6354551e0b5c451a948814fc47fe745a14eac7835c087d60162661019db4"
+checksum = "5092f66eb3563a01e85552731ae82c04c934ff4efd7ad1a0deae7b948f4b3ec4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -464,26 +465,6 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
-]
-
-[[package]]
-name = "linkme"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ed2ee9464ff9707af8e9ad834cffa4802f072caad90639c583dd3c62e6e608"
-dependencies = [
- "linkme-impl",
-]
-
-[[package]]
-name = "linkme-impl"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba125974b109d512fccbc6c0244e7580143e460895dfd6ea7f8bbb692fd94396"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
 ]
 
 [[package]]

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 pomsky = { version = "0.11.0", path = "../pomsky-lib" }
-divan = "0.1.2"
+divan = "0.1.11"
 melody_compiler = "0.19.0"
 
 [[bench]]

--- a/benchmark/benches/main.rs
+++ b/benchmark/benches/main.rs
@@ -92,10 +92,10 @@ mod compile {
     );
 }
 
-#[divan::bench(consts = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13])]
-pub fn range<const N: usize>(bencher: divan::Bencher) {
-    let max = "3458709621".repeat((N + 9) / 10);
-    let max = &max[..N];
+#[divan::bench(args = 1..=13)]
+pub fn range(bencher: divan::Bencher, n: usize) {
+    let max = "3458709621".repeat((n + 9) / 10);
+    let max = &max[..n];
     let input = format!("range '0'-'{max}'");
 
     bencher


### PR DESCRIPTION
<!--
    The title should start with one of the following:
        feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
    For example: "feat: frobnicate syntax"
-->

# Description

<!--
    Please include a summary of the change and which issue is fixed.
    If there's no issue, please explain why this change is needed.
    If this is a breaking change, add the word **BREAKING** in bold.
-->

This greatly reduces compile times and is not limited to arrays/slices.

<!-- Checklist:
   - My code is formatted with `cargo fmt`
   - My code compiles with the latest stable Rust toolchain
   - All tests pass with `cargo test`
   - My changes generate no new warnings with `cargo clippy`
   - I have commented my code, particularly in hard to understand areas
   - My changes are covered by tests, if needed
-->
